### PR TITLE
add example to compute the determinant of an array (python-numpy)

### DIFF
--- a/inbox/numpy-compute-determinant.py
+++ b/inbox/numpy-compute-determinant.py
@@ -1,0 +1,4 @@
+import numpy as np
+mtx = np.array([[1, 2], [3, 4]])
+det = np.linalg.det(mtx)
+print(f"{det} should be -2")


### PR DESCRIPTION
fixes #1236 